### PR TITLE
Update depolarizing_channel.ipynb

### DIFF
--- a/depolarizing_channel/depolarizing_channel.ipynb
+++ b/depolarizing_channel/depolarizing_channel.ipynb
@@ -50,7 +50,7 @@
     "                                                MeasurementFilter)\n",
     "\n",
     "# Utility functions\n",
-    "from qiskit.tools.qi.qi import partial_trace\n",
+    "from qiskit.quantum_info import partial_trace\n",
     "from qiskit.tools.jupyter import *\n",
     "from qiskit.tools.monitor import job_monitor\n",
     "from qiskit.providers.jobstatus import JobStatus"


### PR DESCRIPTION
I think it is better to change in the imports part "from qiskit.tools.qi.qi import partial_trace" to "from qiskit.quantum_info import partial_trace " 
because in the newer version of Qiskit that library does not work well.